### PR TITLE
chore: update required PHP version to 8.0 and other packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 vendor
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ dist: xenial
 language: php
 
 php:
-  - '7.1'
-  - '7.2'
-  - '7.3'
-  - '7.4'
+  - '8.0'
+  - '8.1'
+  - '8.2'
   - 'nightly'
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ echo canonicalize(uri($url)); // http://example.org/bar/
 
 ## Installation
 
-PHP 7.1+ is required.
+PHP 8.0+ is required.
 
 > composer require bentools/uri-factory
 

--- a/composer.json
+++ b/composer.json
@@ -13,19 +13,19 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": ">=7.1",
+        "php": ">=8.0",
         "psr/http-factory": "^1.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "guzzlehttp/psr7": "^1.4",
-        "league/uri": "^5.0",
-        "nyholm/psr7": "^1.1",
-        "php-coveralls/php-coveralls": "^2.1",
-        "phpunit/phpunit": "~6.0|~7.0",
+        "guzzlehttp/psr7": "^2.5",
+        "league/uri": "^5.3",
+        "nyholm/psr7": "^1.6",
+        "php-coveralls/php-coveralls": "^2.5",
+        "phpunit/phpunit": "^9.6",
         "ringcentral/psr7": "^1.3",
         "squizlabs/php_codesniffer": "@stable",
-        "symfony/var-dumper": "^3.3"
+        "symfony/var-dumper": "^5.4 || ^6.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
@@ -14,14 +15,15 @@
          stopOnError="false"
          stopOnFailure="false"
          verbose="true"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
 >
     <testsuite name="tests">
         <directory suffix="Test.php">tests</directory>
     </testsuite>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
+    <coverage processUncoveredFiles="true">
+        <include>
             <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/tests/UriFactoryTest.php
+++ b/tests/UriFactoryTest.php
@@ -2,13 +2,11 @@
 
 namespace BenTools\UriFactory\Tests;
 
-use BenTools\UriFactory\Adapter\GuzzleAdapter;
-use BenTools\UriFactory\Adapter\LeagueUriAdapter;
 use BenTools\UriFactory\UriFactory;
-use GuzzleHttp\Psr7\Uri as GuzzleUri;
-use League\Uri\Http as LeagueUri;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\UriInterface;
+use RuntimeException;
+
 use function BenTools\UriFactory\Helper\current_location;
 use function BenTools\UriFactory\Helper\uri;
 
@@ -37,11 +35,10 @@ class UriFactoryTest extends TestCase
         unset($_SERVER['REQUEST_URI'], $_SERVER['HTTP_HOST']);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testRequestUriFailsOnCli()
     {
+        $this->expectException(RuntimeException::class);
+
         current_location();
     }
 }


### PR DESCRIPTION
This PR changes required PHP version to `8.0`.

It changes too this packages:
- `psr/http-message`: added `2.0`
- `guzzlehttp/psr7` from `1.4` to `2.5` (last version)
- `league/uri` from `5.0` to `5.3` (not the last version because of deletion of `League\Uri\Factory`)
- `nyholm/psr7` from `1.1` to `1.6` (last version)
- `php-coveralls/php-coveralls` from `2.1` to `2.5` (last version)
- `phpunit/phpunit` (not the last version because of difference between 9 and 10. Migrate the configuration file, add the cache file to `.gitignore` and a test with exception)
- `symfony/var-dumper` from `3.3` to `5.4` or `6.2` (last versions)